### PR TITLE
feat: adds more info to imaging response

### DIFF
--- a/aind-slims-service-server/pyproject.toml
+++ b/aind-slims-service-server/pyproject.toml
@@ -84,7 +84,7 @@ line_length = 79
 profile = "black"
 
 [tool.interrogate]
-exclude = ["setup.py", "docs", "build"]
+exclude = ["setup.py", "docs", "build", "env"]
 fail-under = 100
 
 [tool.pytest.ini_options]

--- a/aind-slims-service-server/src/aind_slims_service_server/handlers/imaging.py
+++ b/aind-slims-service-server/src/aind_slims_service_server/handlers/imaging.py
@@ -150,6 +150,13 @@ class ImagingSessionHandler(SlimsTableHandler):
                             "ordr_cf_fluorescenceChannels_CellSegmentation",
                         )
                     )
+                    spim_data.order_created_by = self.get_attr_or_none(
+                        row,
+                        "ordr_createdBy",
+                    )
+                    spim_data.order_project_id = self.get_attr_or_none(
+                        row, "ordr_cf_fk_projectId", "displayValue"
+                    )
             if subject_id is None or subject_id == spim_data.subject_id:
                 spim_data_list.append(spim_data)
         return spim_data_list

--- a/aind-slims-service-server/src/aind_slims_service_server/models.py
+++ b/aind-slims-service-server/src/aind_slims_service_server/models.py
@@ -86,6 +86,8 @@ class SlimsSpimData(BaseModel):
     """Expected Model that needs to be extracted from SLIMS"""
 
     experiment_run_created_on: Optional[AwareDatetime] = None
+    order_created_by: Optional[str] = None
+    order_project_id: Optional[str] = None
     specimen_id: Optional[str] = None
     subject_id: Optional[str] = None
     protocol_name: Optional[str] = None

--- a/aind-slims-service-server/tests/conftest.py
+++ b/aind-slims-service-server/tests/conftest.py
@@ -202,6 +202,8 @@ def test_imaging_data():
     return [
         SlimsSpimData(
             experiment_run_created_on=1739383241200,
+            order_project_id="Some Project - Some Subproject 1",
+            order_created_by="PersonS",
             specimen_id="BRN00000018",
             subject_id="744742",
             protocol_name="Imaging cleared mouse brains on SmartSPIM",

--- a/aind-slims-service-server/tests/resources/imaging/order.json
+++ b/aind-slims-service-server/tests/resources/imaging/order.json
@@ -58,6 +58,28 @@
             "value": null,
             "hidden": false,
             "editable": true
+            },
+            {
+                "datatype": "FOREIGN_KEY", 
+                "name": "ordr_cf_fk_projectId", 
+                "title": "Project ID", 
+                "position": 19, 
+                "value": 1975, 
+                "hidden": false, 
+                "editable": true, 
+                "foreignTable": "ReferenceDataRecord", 
+                "displayValue": "Some Project - Some Subproject 1",
+                "displayField": "ordr_cf_fk_projectId_display", 
+                "foreignDisplayColumn": "rdrc_name"
+            },
+            {
+                "datatype": "STRING", 
+                "name": "ordr_createdBy", 
+                "title": "Created by", 
+                "position": 30, 
+                "value": "PersonS", 
+                "hidden": false, 
+                "editable": true
             }
         ]
     }


### PR DESCRIPTION
- Adds `order_created_by` and `order_project_id` info to slims response
- Adds `env` to interrogate exclusion list 