### PR TITLE
Fix: HistologyWash mass field expects an int

### DIFF
--- a/aind-slims-service-server/src/aind_slims_service_server/models.py
+++ b/aind-slims-service-server/src/aind_slims_service_server/models.py
@@ -1,7 +1,7 @@
 """Models and schema definitions for backend data structures"""
 
 from decimal import Decimal
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional
 
 from pydantic import AwareDatetime, BaseModel
 

--- a/aind-slims-service-server/src/aind_slims_service_server/models.py
+++ b/aind-slims-service-server/src/aind_slims_service_server/models.py
@@ -1,7 +1,7 @@
 """Models and schema definitions for backend data structures"""
 
 from decimal import Decimal
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from pydantic import AwareDatetime, BaseModel
 
@@ -125,7 +125,7 @@ class HistologyWashData(BaseModel):
     end_time: Optional[AwareDatetime] = None
     modified_by: Optional[str] = None
     reagents: List[HistologyReagentData] = []
-    mass: Optional[Decimal] = None
+    mass: Optional[int] = None
 
 
 class SlimsHistologyData(BaseModel):


### PR DESCRIPTION
closes #37 

This PR:
- updates the definition of `HistologyWashData.mass` to expect `int` not `Decimal` (the openapi generator serializes Decimal as StrictStr so although `Decimal` works for the server, it fails validation with client)
- I downloaded all of the histology data from SLIMS to double check the type of the `mass` field. They were all None or `int`